### PR TITLE
fix swagger docs and follow endpoint

### DIFF
--- a/app/backend/v1/apps/accounts/tests.py
+++ b/app/backend/v1/apps/accounts/tests.py
@@ -90,7 +90,7 @@ class FollowUserTest(TestCase):
         self.client = APIClient()
         self.follower = CustomUser.objects.create_user(username="follower", password="password")
         self.following = CustomUser.objects.create_user(username="following", password="password")
-        self.url = reverse('toggle-follow', args=[self.following.id])
+        self.url = reverse('toggle-follow', args=[self.following.username])
 
     def test_follow_user_authenticated(self):
         self.client.force_authenticate(user=self.follower)

--- a/app/backend/v1/apps/accounts/urls.py
+++ b/app/backend/v1/apps/accounts/urls.py
@@ -4,7 +4,7 @@ from . import views
 urlpatterns = [
     path('signup/', views.sign_up, name='sign-up'),
     path('login/', views.login, name='login'),
-    path('<int:user_id>/follow/', views.toggle_follow, name='toggle-follow'),
+    path('<str:username>/follow/', views.toggle_follow, name='toggle-follow'),
     path('me/', views.get_user_page, name='get-user-page'),
     path('<int:user_id>/', views.get_other_user_page, name='get-other-user-page'),
 ]

--- a/app/backend/v1/apps/accounts/views.py
+++ b/app/backend/v1/apps/accounts/views.py
@@ -12,6 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from v1.apps.posts.models import PostBookmark, Like, Post
 from v1.apps.games.models import GameBookmark, GameMoveBookmark
 from django.shortcuts import get_object_or_404
+from v1.apps.headers import auth_header
 User = get_user_model()
 
 # Sign-up view
@@ -102,6 +103,7 @@ def login(request):
     method='post',
     operation_description="Toggle follow/unfollow for a specific user. If the user is not followed, the current user will follow them. If the user is already followed, the follow will be removed.",
     operation_summary="Toggle Follow on a User",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response(
             description="User followed successfully",
@@ -126,14 +128,22 @@ def login(request):
                     'error': 'User not found'
                 }
             }
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
         )
     }
 )
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
-def toggle_follow(request, user_id):
+def toggle_follow(request, username):
     try:
-        following_user = CustomUser.objects.get(id=user_id)
+        following_user = CustomUser.objects.get(username=username)
     except CustomUser.DoesNotExist:
         return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
 
@@ -154,6 +164,7 @@ def toggle_follow(request, user_id):
     method='get',
     operation_description="Retrieve all user-related information for the authenticated user's profile page. This includes the user's general information (username, email, etc.), bookmarks (post, game, and game move), likes, followers, followings, and user's posts.",
     operation_summary="Get User Page Data",
+    manual_parameters=[auth_header],
     responses={
         200: openapi.Response(
             description="User page data retrieved successfully",

--- a/app/backend/v1/apps/games/views.py
+++ b/app/backend/v1/apps/games/views.py
@@ -151,7 +151,15 @@ until_param = openapi.Parameter(
     responses={
         200: openapi.Response('Data fetched successfully', examples={'application/json': {'data': '...'}}),
         400: openapi.Response('Invalid request'),
-        500: openapi.Response('Error fetching data')
+        500: openapi.Response('Error fetching data'),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @api_view(['GET'])
@@ -219,6 +227,14 @@ game_id_param = openapi.Parameter(
         500: openapi.Response(
             description="Server error.",
             examples={'application/json': {'error': 'Internal server error'}}
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
         )
     },
     operation_description="Fetch the PGN representation of a master game from public API's.",
@@ -254,6 +270,7 @@ def master_game(request, game_id):
     method='post',
     operation_description="Add a comment to a specific move in a game.",
     operation_summary="Add Game Comment",
+    manual_parameters=[auth_header],
     request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         properties={
@@ -282,6 +299,14 @@ def master_game(request, game_id):
         }),
         400: openapi.Response(description="Invalid data"),
         404: openapi.Response(description="Game not found"),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     },
 )
 @api_view(['POST'])
@@ -358,6 +383,7 @@ def list_game_comments(request, game_id):
     method='post',
     operation_description="Toggle bookmark for a specific game. If the game is not bookmarked, it will be bookmarked. If it is already bookmarked, the bookmark will be removed.",
     operation_summary="Toggle Bookmark on a Game",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response(
             description="Game bookmarked successfully",
@@ -382,6 +408,14 @@ def list_game_comments(request, game_id):
                     'error': 'Game not found'
                 }
             }
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
         )
     }
 )
@@ -404,6 +438,7 @@ def toggle_game_bookmark(request, game_id):
     method='post',
     operation_description="Toggle bookmark for a specific move in a game. If the move is not bookmarked, it will be bookmarked. If it is already bookmarked, the bookmark will be removed.",
     operation_summary="Toggle Bookmark on a Game Move",
+    manual_parameters=[auth_header],
     request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
         properties={
@@ -439,6 +474,14 @@ def toggle_game_bookmark(request, game_id):
             examples={
                 'application/json': {
                     'error': 'Game or move not found'
+                }
+            }
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
                 }
             }
         )

--- a/app/backend/v1/apps/posts/views.py
+++ b/app/backend/v1/apps/posts/views.py
@@ -13,6 +13,7 @@ from v1.apps.posts.serializers import PostSerializer, LikeSerializer, CommentSer
 
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.pagination import PageNumberPagination
+from v1.apps.headers import auth_header
 
 
 # Swagger documentation for POST /api/v1/posts/create/
@@ -42,6 +43,7 @@ from rest_framework.pagination import PageNumberPagination
     ),
     operation_description="Create a post with an optional base64-encoded image, FEN notation, text content and a list of tags. Requires authentication.",
     operation_summary="Create a new post",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response(
             description="Post created successfully",
@@ -64,6 +66,14 @@ from rest_framework.pagination import PageNumberPagination
                 'application/json': {
                     'post_image': ['Invalid image format.'],
                     'fen': ['This field is required.'],
+                }
+            }
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
                 }
             }
         )
@@ -189,10 +199,19 @@ def list_posts(request):
     method='post',
     operation_description="Toggle like/unlike for a specific post.",
     operation_summary="Like/Unlike a Post",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response("Post liked", examples={"application/json": {"message": "Post liked"}}),
         200: openapi.Response("Post unliked", examples={"application/json": {"message": "Post unliked"}}),
-        404: "Post not found"
+        404: "Post not found",
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @api_view(['POST'])
@@ -219,6 +238,7 @@ def like_post(request, post_id):
     ),
     operation_description="Get like count and like status for multiple posts.",
     operation_summary="Like Summary for Multiple Posts",
+    manual_parameters=[auth_header],
     responses={
         200: openapi.Response(
             description="Like summary retrieved",
@@ -228,7 +248,15 @@ def like_post(request, post_id):
                 {"post_id": 3, "error": "Post not found"}
             ]}
         ),
-        400: "Invalid request"
+        400: "Invalid request",
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @api_view(['POST'])
@@ -277,6 +305,7 @@ comment_id_param = openapi.Parameter(
     ),
     operation_description="Add a new comment to a specific post. Optionally include FEN notations.",
     operation_summary="Create Comment",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response(
             description="Comment created successfully.",
@@ -293,7 +322,15 @@ comment_id_param = openapi.Parameter(
             }
         ),
         400: "Invalid request",
-        404: "Post not found"
+        404: "Post not found",
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @api_view(['POST'])
@@ -330,6 +367,7 @@ def create_comment(request, post_id):
     ),
     operation_description="Update an existing comment on a specific post. Optionally include FEN notations.",
     operation_summary="Update Comment",
+    manual_parameters=[auth_header],
     responses={
         200: openapi.Response(
             description="Comment updated successfully.",
@@ -347,17 +385,34 @@ def create_comment(request, post_id):
         ),
         400: "Invalid request",
         403: "Unauthorized",
-        404: "Comment not found"
+        404: "Comment not found",
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @swagger_auto_schema(
     method='delete',
     operation_description="Delete an existing comment on a specific post.",
     operation_summary="Delete Comment",
+    manual_parameters=[auth_header],
     responses={
         204: "Comment deleted successfully",
         403: "Unauthorized",
-        404: "Comment not found"
+        404: "Comment not found",
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
+                }
+            }
+        )
     }
 )
 @api_view(['PUT', 'DELETE'])
@@ -438,6 +493,7 @@ def list_comments(request, post_id):
     method='post',
     operation_description="Toggle bookmark for a specific post. If the post is not bookmarked, it will be bookmarked. If it is already bookmarked, the bookmark will be removed.",
     operation_summary="Toggle Bookmark on a Post",
+    manual_parameters=[auth_header],
     responses={
         201: openapi.Response(
             description="Post bookmarked successfully",
@@ -460,6 +516,14 @@ def list_comments(request, post_id):
             examples={
                 'application/json': {
                     'error': 'Post not found'
+                }
+            }
+        ),
+        401: openapi.Response(
+            description="Authentication required",
+            examples={
+                'application/json': {
+                    "detail": "Authentication credentials were not provided."
                 }
             }
         )


### PR DESCRIPTION
- Added authentication headers and 401 responses to Swagger documentation for all IsAuthenticated endpoints to allow proper testing via Swagger API.
- Updated follow/unfollow endpoint to use username instead of user_id for better client compatibility.