### PR TITLE
Backend Tournaments

### DIFF
--- a/app/backend/v1/apps/games/urls.py
+++ b/app/backend/v1/apps/games/urls.py
@@ -10,4 +10,6 @@ urlpatterns = [
     path('<int:game_id>/bookmark/', views.toggle_game_bookmark, name='toggle-game-bookmark'),
     path('<int:game_id>/move/bookmark/', views.toggle_game_move_bookmark, name='toggle-game-move-bookmark'),
     path('openings/', views.get_opening_by_eco, name='get-opening-by-eco'),
+    path('current_tournaments/', views.get_current_tournaments, name='get-current-tournaments'),
+
 ]

--- a/app/backend/v1/apps/games/urls.py
+++ b/app/backend/v1/apps/games/urls.py
@@ -10,6 +10,8 @@ urlpatterns = [
     path('<int:game_id>/bookmark/', views.toggle_game_bookmark, name='toggle-game-bookmark'),
     path('<int:game_id>/move/bookmark/', views.toggle_game_move_bookmark, name='toggle-game-move-bookmark'),
     path('openings/', views.get_opening_by_eco, name='get-opening-by-eco'),
-    path('current_tournaments/', views.get_current_tournaments, name='get-current-tournaments'),
-
+    path('tournaments/', views.get_current_tournaments, name='get-current-tournaments'),
+    path('tournaments/<str:tournamentSlug>/<str:roundSlug>/<str:roundId>/',views.get_tournament_round,name='get-tournament-round'),
+    path('tournament/round/<str:roundId>/pgn/', views.get_tournament_round_pgn, name='get-tournament-round-pgn'),
 ]
+

--- a/app/backend/v1/apps/puzzle/views.py
+++ b/app/backend/v1/apps/puzzle/views.py
@@ -135,7 +135,7 @@ def random_puzzle(request):
     """
     Fetch a random puzzle from Lichess API with optional filters for theme or difficulty.
     """
-    url = f"{LICHESS_API_BASE_URL}/puzzle"
+    url = f"{LICHESS_API_BASE_URL}/puzzle/next"
     params = {}
 
     # Extract optional parameters from the request


### PR DESCRIPTION
# Add Tournament and PGN Fetching Endpoints

## Description

This PR introduces three new endpoints to enhance the chess tournament features of the application. These endpoints allow fetching tournament details, round-specific information, and PGN (Portable Game Notation) data for games in a specific round. The functionality integrates with the Lichess Broadcast API to retrieve real-time chess tournament data.

## Endpoints

### 1. **Get Current Tournaments**
- **Path**: `tournaments/`
- **Function**: `get_current_tournaments`
- **Description**: 
  - Fetches the list of currently ongoing tournaments.
  - Provides essential metadata such as tournament name, description, start and end times, and tier.
  - Utilizes the Lichess API to fetch the live tournament details.

---

### 2. **Get Tournament Round Details**
- **Path**: `tournaments/<str:tournamentSlug>/<str:roundSlug>/<str:roundId>/`
- **Function**: `get_tournament_round`
- **Description**: 
  - Fetches detailed information about a specific tournament round.
  - Includes metadata such as round ID, round name, participating players, and live URLs for games.
  - Maps games using player names and integrates group or tournament-level details.

---

### 3. **Get PGNs for a Tournament Round**
- **Path**: `tournament/round/<str:roundId>/pgn/`
- **Function**: `get_tournament_round_pgn`
- **Description**: 
  - Fetches the PGN representation of all games in a specific tournament round.
  - Maps PGNs to human-readable keys in the format: `WhitePlayer - BlackPlayer`.
  - Captures headers and moves from the Lichess PGN API for detailed game reconstruction.

## Testing
- Ensured PGN parsing is accurate and includes all headers and moves.
- Verified API responses for valid and invalid inputs (e.g., missing round IDs or invalid tournament slugs).
- Tested integration with Lichess API under various conditions (e.g., no ongoing tournaments).

